### PR TITLE
fix: Allow options to be optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,7 @@ class Toast {
     )
   })
 
-  add(message: string, options: Options) {
+  add(message: string, options: Options = {}) {
     const usableOptions: Options = {
       position: options.position ?? 'top-center',
       type: options.type ?? 'default',
@@ -259,20 +259,20 @@ export const Toaster = () => {
 
 const toastTypes = ['success', 'error', 'info', 'warning'] as const
 
-export type ToastHelper = ((message: string, options: Options) => void) & {
+export type ToastHelper = ((message: string, options?: Options) => void) & {
   [k in (typeof toastTypes)[number]]: (
     message: string,
     options: Omit<Options, 'type'>
   ) => void
 }
 
-export const toast = ((message: string, options: Options) => {
+export const toast = ((message: string, options?: Options) => {
   toastsContainer.add(message, options)
   return
 }) as ToastHelper
 
 toastTypes.forEach(d => {
-  toast[d] = (message: string, options: Omit<Options, 'type'>) => {
+  toast[d] = (message: string, options?: Omit<Options, 'type'>) => {
     return toast(message, { ...options, type: d })
   }
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -262,7 +262,7 @@ const toastTypes = ['success', 'error', 'info', 'warning'] as const
 export type ToastHelper = ((message: string, options?: Options) => void) & {
   [k in (typeof toastTypes)[number]]: (
     message: string,
-    options: Omit<Options, 'type'>
+    options?: Omit<Options, 'type'>
   ) => void
 }
 


### PR DESCRIPTION
(Hope you don't mind a couple drive-by fixes)

The example shown in the readme doesn't quite work at the moment as both the types & underlying JS expect a second param passed to `toast()`. This seems unintentional, so I made the param optional in the types & added an initializer in `Toast#add`