### PR TITLE
fix: Make preact & @preact/signals peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,6 @@
 - 📦 Tiny bundle size (~1KB GZipped)
 - 🤌 Simple API
 
-## Pre-requisites
-
-- You need to have `@preact/signals` installed
-
-```sh
-npm i @preact/signals
-```
-
 ## Install
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "scripts": {
     "dev": "concurrently 'pnpm:build watch' 'pnpm:build:docs watch'",
     "build": "pnpm build:js && pnpm build:docs",
-    "build:js": "microbundle -f modern --jsxImportSource preact --external=preact,@preact/signals",
-    "build:docs": "microbundle -f modern --jsxImportSource preact --external=preact,@preact/signals -o docs/bundle",
+    "build:js": "microbundle -f modern",
+    "build:docs": "microbundle -f modern -o docs/bundle",
     "fix": "biome check --fix .",
     "prepare": "husky",
     "next": "bumpp",
@@ -59,8 +59,11 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@preachjs/popper": "^0.0.6",
-    "@preact/signals": "^2.0.1"
+    "@preachjs/popper": "^0.0.6"
+  },
+  "peerDependencies": {
+    "@preact/signals": "^2.0.1",
+    "preact": "^10"
   },
   "packageManager": "pnpm@9.15.9"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { h } from 'preact'
 import { Signal, computed, effect, signal } from '@preact/signals'
 import { forwardRef } from 'preact/compat'
 import { useCallback } from 'preact/hooks'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
     "moduleResolution": "bundler",
     "declaration": true,
     "outDir": "dist",
-    "jsx": "preserve",
+    "jsx": "react",
+    "jsxFactory": "h",
     "lib": ["ES2015"],
-    "jsxImportSource": "preact",
     "rootDir": "./src",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Just some quick thoughts, feel free to ignore if you disagree/have a situation in mind that necessitates this setup! Plenty of nuance here for sure.

Accessing `preact` but not listing it as a peer dep is "unsound" and I know Yarn will throw a fit over it (not that I necessarily pay them much mind myself, but... they do have a point) and listing `@preact/signals` as a dependency means it'll always be installed, even if the user brings their own copy. This means users can end up with multiple copies installed at once, and I'm guessing by your ReadMe instructions this isn't the intention, so a peer dep is likely a better fit here. If the user already has a copy of `@preact/signals` installed, the package manager will use that, else, it'll install one.

As for the build commands, Microbundle automatically externalizes all peer deps, so the `--external` flag can be dropped, and using the classic JSX transform saves 24b gzip & 20b br, pushing this down to sub 1kb w/ br. Unless you have a particular need for the runtime transform, classic results in slightly smaller sizes as it skips another import statement.