### PR TITLE
refactor: Swap out 'forwardRef' for a tiny diff hook

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,20 @@
 import { Signal, computed, effect, signal } from '@preact/signals'
-import { forwardRef } from 'preact/compat'
+import { Ref, VNode, options } from 'preact'
 import { useCallback } from 'preact/hooks'
+
+// @ts-expect-error - Preact's `_diff` hook is not part of the public types
+const oldDiff = options.__b
+// @ts-ignore
+options.__b = vnode => {
+  if (vnode.type === ToastMessageRenderer && vnode.ref) {
+    vnode.props.ref = vnode.ref
+    vnode.ref = null
+  }
+
+  if (oldDiff) oldDiff(vnode)
+}
+
+export type Type = 'success' | 'error' | 'info' | 'warning' | 'default'
 
 export type Options = {
   position?:
@@ -10,7 +24,7 @@ export type Options = {
     | 'bottom-center'
     | 'bottom-start'
     | 'bottom-end'
-  type?: 'success' | 'error' | 'info' | 'warning' | 'default'
+  type?: Type
   closeDelay?: number
 }
 
@@ -83,10 +97,19 @@ class Toast {
   }
 }
 
-export const ToastMessageRenderer = forwardRef<
-  HTMLDivElement,
-  { message: string; visible: boolean; type: string }
->(({ message, visible, type }, ref) => {
+export type ToastMessageRendererProps = {
+  message: string
+  visible: boolean
+  type: Type
+  ref: Ref<HTMLDivElement>
+}
+
+export const ToastMessageRenderer = ({
+  message,
+  visible,
+  type,
+  ref,
+}: ToastMessageRendererProps) => {
   return (
     <div
       ref={ref}
@@ -99,7 +122,7 @@ export const ToastMessageRenderer = forwardRef<
       {message}
     </div>
   )
-})
+}
 
 const toastsContainer = new Toast()
 


### PR DESCRIPTION
As you know, `preact/compat` is side effectful so any use of any export pretty much drags in the whole thing. `forwardRef` is really easy to swap out with a tiny `_diff` hook though, avoiding the need to pull in all of compat. While this increases the size of the bundled lib a bit, it decreases the overall size in cases where the user isn't using compat already (which isn't uncommon, IME).

While I was at it I extracted the `Type` union for reuse as `ToastMessageRenderer` previously typed it as simply `string`. Not a big deal but thought it couldn't hurt.