### PR TITLE
fix: Support node16 TS type resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-export * from './toast'
+export * from './toast.js'
 export {
   Options,
   ToastContext,
   ToastHelper,
   ToastMessageRendererProps,
   Type,
-} from './types'
+} from './types.js'

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -1,4 +1,4 @@
-import { Options, ToastHelper } from './types'
+import { Options, ToastHelper } from './types.js'
 
 export type PromiseOptions = {
   error?: string

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -2,7 +2,7 @@ import { Signal, computed, effect, signal } from '@preact/signals'
 import { Fragment, Ref, VNode, h, options } from 'preact'
 import type { JSX } from 'preact'
 import { useCallback, useMemo } from 'preact/hooks'
-import { createToastPromise } from './promise'
+import { createToastPromise } from './promise.js'
 import {
   MessageInput,
   Options,
@@ -11,7 +11,7 @@ import {
   ToastMessageRendererProps,
   Type,
   _InternalMessage,
-} from './types'
+} from './types.js'
 
 declare module 'preact' {
   interface Options {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Signal } from '@preact/signals'
 import { Ref } from 'preact'
 import type { JSX } from 'preact'
-import { PromiseOptions } from './promise'
+import { PromiseOptions } from './promise.js'
 
 export type MessageInput = string | (() => JSX.Element)
 


### PR DESCRIPTION
Super duper dumb & gross, but TS requires file extensions with the new-er module resolution (in ESM? Not 100% sure) and Microbundle won't add automatically. As it is, the types just error out/cannot be detected at the moment.

https://arethetypeswrong.github.io/?p=%40preachjs%2Ftoast%400.0.3

Running `npm pack` & uploading the tarball to that site shows that, with this change, those module resolution errors should go away.