### PR TITLE
fix: Ensure toast variant types work

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ToastHelper = ((
   message: MessageInput,
   options?: Options
 ) => ToastContext) & {
-  [k in Type[number]]: (
+  [k in Type]: (
     message: MessageInput,
     options?: Omit<Options, 'type'>
   ) => ToastContext


### PR DESCRIPTION
To be quite honest I have no idea what the `[number]` is/was for, but it seems to break the types? None of the variants show up as recognized properties to me, and it also will allow any arbitrary property such as `.foo`. I'm guessing TS just sorta bails there.

Not quite sure if this goes beyond my TS understanding (very possible) or just a simple typo. 